### PR TITLE
Fix #7: Unicode error on non-ascii content.

### DIFF
--- a/autosub/formatters.py
+++ b/autosub/formatters.py
@@ -1,11 +1,23 @@
+# -*- coding: utf-8 -*-
+import sys
 import json
+
 import pysrt
+
+text_type = unicode if sys.version_info < (3,) else str
+
+
+def force_unicode(s, encoding="utf-8"):
+    if isinstance(s, text_type):
+        return s
+    return s.decode(encoding)
+
 
 def srt_formatter(subtitles, show_before=0, show_after=0):
     f = pysrt.SubRipFile()
     for (rng, text) in subtitles:
         item = pysrt.SubRipItem()
-        item.text = text
+        item.text = force_unicode(text)
         start, end = rng
         item.start.seconds = max(0, start - show_before)
         item.end.seconds = end + show_after

--- a/bin/autosub
+++ b/bin/autosub
@@ -244,7 +244,8 @@ def main():
         base, ext = os.path.splitext(args.source_path)
         dest = "{base}.{format}".format(base=base, format=args.format)
 
-    open(dest, 'wb').write(formatted_subtitles)
+    with open(dest, 'wb') as f:
+        f.write(formatted_subtitles.encode("utf-8"))
 
     print "Subtitles file created at {}".format(dest)
 


### PR DESCRIPTION
I've run into the same issue. 

It seems `pysrt.SubRipItem` enforces unicode for python 2.
This patch should fix the problem.