### PR TITLE
Improve the speed of converting flac files

### DIFF
--- a/bin/autosub
+++ b/bin/autosub
@@ -46,8 +46,8 @@ class FLACConverter(object):
             start = max(0, start - self.include_before)
             end += self.include_after
             temp = tempfile.NamedTemporaryFile(suffix='.flac')
-            command = ["ffmpeg", "-y", "-i", self.source_path,
-                       "-ss", str(start), "-t", str(end - start),
+            command = ["ffmpeg","-ss", str(start), "-t", str(end - start),
+                       "-y", "-i", self.source_path,
                        "-loglevel", "error", temp.name]
             subprocess.check_output(command)
             os.system('stty sane')


### PR DESCRIPTION
Improve the speed of converting flac files for large files.
"When used as an input option (before -i), seeks in this input file to position. When used as an output option (before an output filename), decodes but discards input until the timestamps reach position. This is slower, but more accurate."

http://stackoverflow.com/questions/6984628/ffmpeg-ss-weird-behaviour.
For Movies 2 hrs, is notable performance.

3-10 minutes vs 2 seg For convert flac.
