### PR TITLE
Bug fixed

### DIFF
--- a/bin/autosub
+++ b/bin/autosub
@@ -174,7 +174,7 @@ def find_speech_regions(filename, frame_width=4096, min_region_size=0.5, max_reg
         if (max_exceeded or is_silence) and region_start:
             if elapsed_time - region_start >= min_region_size:
                 regions.append((region_start, elapsed_time))
-            region_start = None
+                region_start = None
 
         elif (not region_start) and (not is_silence):
             region_start = elapsed_time


### PR DESCRIPTION
Added an indent at line 177
There was a logical fault, the subtitle time line should have been continuous. But it skipped some parts because it set the "region_start" to "None" unexpectedly. 
The line 177 should be in the range of "if"