### PR TITLE
Fix error when run ffmpeg on Windows

### DIFF
--- a/bin/autosub
+++ b/bin/autosub
@@ -49,7 +49,8 @@ class FLACConverter(object):
             command = ["ffmpeg","-ss", str(start), "-t", str(end - start),
                        "-y", "-i", self.source_path,
                        "-loglevel", "error", temp.name]
-            subprocess.check_output(command, stdin=open(os.devnull))
+            use_shell = True if os.name == "nt" else False
+            subprocess.check_output(command, stdin=open(os.devnull), shell=use_shell)
             return temp.read()
 
         except KeyboardInterrupt:
@@ -139,7 +140,8 @@ def extract_audio(filename, channels=1, rate=16000):
         print "ffmpeg: Executable not found on machine."
         raise Exception("Dependency not found: ffmpeg")
     command = ["ffmpeg", "-y", "-i", filename, "-ac", str(channels), "-ar", str(rate), "-loglevel", "error", temp.name]
-    subprocess.check_output(command, stdin=open(os.devnull))
+    use_shell = True if os.name == "nt" else False
+    subprocess.check_output(command, stdin=open(os.devnull), shell=use_shell)
     return temp.name, rate
 
 

--- a/bin/autosub
+++ b/bin/autosub
@@ -150,8 +150,6 @@ def find_speech_regions(filename, frame_width=4096, min_region_size=0.5, max_reg
     sample_width = reader.getsampwidth()
     rate = reader.getframerate()
     n_channels = reader.getnchannels()
-
-    total_duration = reader.getnframes() / rate
     chunk_duration = float(frame_width) / rate
 
     n_chunks = int(math.ceil(reader.getnframes()*1.0 / frame_width))


### PR DESCRIPTION
On some Windows machine, when subprocess ffmpeg runs, leads to errors look like this.

> bellowubprocess.CalledProcessError: Command ‘[‘ffmpeg’, ‘-y’, ‘-i’, ‘a.mp4’, ‘-ac’, ‘
> 1’, ‘-ar’, ‘16000’, ‘-loglevel’, ‘error’, ‘c:\\users\\boss\\appdata\\local\\temp
> \\tmpbvht_u.wav’]’ returned non-zero exit status 1

Those errors can be resolved by add argument `shell=True` to `subprocess.checkoutput`