### PR TITLE
Add parameter listener_progress (type function) to the method generate_subtitle

### DIFF
--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -61,7 +61,7 @@ class FLACConverter(object): # pylint: disable=too-few-public-methods
             start, end = region
             start = max(0, start - self.include_before)
             end += self.include_after
-            temp = tempfile.NamedTemporaryFile(suffix='.flac')
+            temp = tempfile.NamedTemporaryFile(suffix='.flac', delete=False)
             command = ["ffmpeg", "-ss", str(start), "-t", str(end - start),
                        "-y", "-i", self.source_path,
                        "-loglevel", "error", temp.name]


### PR DESCRIPTION
So that programs using autosub as a library can conveniently retrieve the progress of the operations (for example to show the progress in a GUI).

I'm currently developing a pyQt interface to offer a more friendly interface with autosub. Calling autosub as a command and listening to the output on shell is not very convenient to get accurate information about the progress of the operations. With this extra parameter will be much easier and convenient to output the progress information to the GUI.

Congratulations and thanks a lot for the great work at autosub. It is a very helpful library and provide unique functionality.

