### PR TITLE
ignore ValueErrors which happen on empty response

### DIFF
--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -99,7 +99,7 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                         line = json.loads(line)
                         line = line['result'][0]['alternative'][0]['transcript']
                         return line[:1].upper() + line[1:]
-                    except IndexError:
+                    except (IndexError, ValueError):
                         # no result
                         continue
 


### PR DESCRIPTION
For some requests Google seems to send us a totally empty response instead of `{"result":[]}`, cf. issue #109.

To me, it is not totally clear when exactly we get which response between `  ` and `{"result":[]}`, but I think we should just handle them the same (ignore) and continue processing the file.

This was the behavior October, 10th when the exception was changed to include only `IndexError`.