### PR TITLE
need to have delete=False, otherwise crash on Windows

### DIFF
--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -102,7 +102,7 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                     except IndexError:
                         # no result
                         continue
-                    
+
         except KeyboardInterrupt:
             return None
 

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -25,6 +25,7 @@ from autosub.constants import (
     LANGUAGE_CODES, GOOGLE_SPEECH_API_KEY, GOOGLE_SPEECH_API_URL,
 )
 from autosub.formatters import FORMATTERS
+from json import JSONDecodeError
 
 DEFAULT_SUBTITLE_FORMAT = 'srt'
 DEFAULT_CONCURRENCY = 10
@@ -61,7 +62,7 @@ class FLACConverter(object): # pylint: disable=too-few-public-methods
             start, end = region
             start = max(0, start - self.include_before)
             end += self.include_after
-            temp = tempfile.NamedTemporaryFile(suffix='.flac',delete=False)
+            temp = tempfile.NamedTemporaryFile(suffix='.flac', delete=False)
             command = ["ffmpeg", "-ss", str(start), "-t", str(end - start),
                        "-y", "-i", self.source_path,
                        "-loglevel", "error", temp.name]
@@ -101,6 +102,8 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                         return line[:1].upper() + line[1:]
                     except IndexError:
                         # no result
+                        continue
+                    except JSONDecodeError:
                         continue
 
         except KeyboardInterrupt:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -25,7 +25,6 @@ from autosub.constants import (
     LANGUAGE_CODES, GOOGLE_SPEECH_API_KEY, GOOGLE_SPEECH_API_URL,
 )
 from autosub.formatters import FORMATTERS
-from json import JSONDecodeError
 
 DEFAULT_SUBTITLE_FORMAT = 'srt'
 DEFAULT_CONCURRENCY = 10
@@ -103,9 +102,7 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                     except IndexError:
                         # no result
                         continue
-                    except JSONDecodeError:
-                        continue
-
+                    
         except KeyboardInterrupt:
             return None
 

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -67,7 +67,10 @@ class FLACConverter(object): # pylint: disable=too-few-public-methods
                        "-loglevel", "error", temp.name]
             use_shell = True if os.name == "nt" else False
             subprocess.check_output(command, stdin=open(os.devnull), shell=use_shell)
-            return temp.read()
+            read_data = temp.read()
+            temp.close()
+            os.unlink(temp.name)
+            return read_data
 
         except KeyboardInterrupt:
             return None
@@ -251,6 +254,7 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
             extracted_regions = []
             for i, extracted_region in enumerate(pool.imap(converter, regions)):
                 extracted_regions.append(extracted_region)
+                print("file: " + extracted_region)
                 pbar.update(i)
             pbar.finish()
 

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -254,7 +254,6 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
             extracted_regions = []
             for i, extracted_region in enumerate(pool.imap(converter, regions)):
                 extracted_regions.append(extracted_region)
-                print("file: " + extracted_region)
                 pbar.update(i)
             pbar.finish()
 

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -61,7 +61,7 @@ class FLACConverter(object): # pylint: disable=too-few-public-methods
             start, end = region
             start = max(0, start - self.include_before)
             end += self.include_after
-            temp = tempfile.NamedTemporaryFile(suffix='.flac')
+            temp = tempfile.NamedTemporaryFile(suffix='.flac',delete=False)
             command = ["ffmpeg", "-ss", str(start), "-t", str(end - start),
                        "-y", "-i", self.source_path,
                        "-loglevel", "error", temp.name]


### PR DESCRIPTION
On Windows if not have delete=False parameter, the temporary file gets deleted before finishing processing, causing subprocess crashing.