### PR TITLE
Sometimes was getting complete crashes because of JSONDecodeError on …

### DIFF
--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -17,7 +17,6 @@ import sys
 import tempfile
 import wave
 
-from json import JSONDecodeError
 import requests
 from googleapiclient.discovery import build
 from progressbar import ProgressBar, Percentage, Bar, ETA
@@ -103,7 +102,7 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                     except IndexError:
                         # no result
                         continue
-                    except JSONDecodeError:
+                    except json.JSONDecodeError:
                         continue
 
         except KeyboardInterrupt:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -15,10 +15,8 @@ import subprocess
 import sys
 import tempfile
 import wave
-
-import requests
-
 import json
+import requests
 try:
     from json.decoder import JSONDecodeError
 except ImportError:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -18,6 +18,11 @@ import tempfile
 import wave
 
 import requests
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 from googleapiclient.discovery import build
 from progressbar import ProgressBar, Percentage, Bar, ETA
 
@@ -102,7 +107,7 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                     except IndexError:
                         # no result
                         continue
-                    except json.JSONDecodeError:
+                    except JSONDecodeError:
                         continue
 
         except KeyboardInterrupt:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import audioop
-import json
 import math
 import multiprocessing
 import os
@@ -18,6 +17,8 @@ import tempfile
 import wave
 
 import requests
+
+import json
 try:
     from json.decoder import JSONDecodeError
 except ImportError:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import wave
 
+from json import JSONDecodeError
 import requests
 from googleapiclient.discovery import build
 from progressbar import ProgressBar, Percentage, Bar, ETA
@@ -101,6 +102,8 @@ class SpeechRecognizer(object): # pylint: disable=too-few-public-methods
                         return line[:1].upper() + line[1:]
                     except IndexError:
                         # no result
+                        continue
+                    except JSONDecodeError:
                         continue
 
         except KeyboardInterrupt:


### PR DESCRIPTION
Sometimes was getting complete crashes because of JSONDecodeError on line = json.loads(line)" because of receiving empty strings. As it can be ignored... this fixes the problem.