### PR TITLE
Fix crash MacOS because of multiprocessing fork

### DIFF
--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -237,7 +237,7 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
         #the default unix fork method does not work on Mac OS
         #need to use forkserver
         try:
-            if 'forkserver' not in multiprocessing.get_start_method():
+            if 'forkserver' not in multiprocessing.get_start_method(allow_none=True):
                 multiprocessing.set_start_method('forkserver')
         except AttributeError:
             # for python 2 not have set_start_method... cannot be used on mac

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -233,7 +233,7 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
     """
     Given an input audio/video file, generate subtitles in the specified language and format.
     """
-    if "Darwin" in os.uname():
+    if os.name != "nt" and "Darwin" in os.uname():
         #the default unix fork method does not work on Mac OS
         #need to use forkserver
         try:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -236,7 +236,11 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
     if "Darwin" in os.uname():
         #the default unix fork method does not work on Mac OS
         #need to use forkserver
-        multiprocessing.set_start_method('forkserver')
+        try:
+            multiprocessing.set_start_method('forkserver')
+        except AttributeError:
+            # for python 2 not have set_start_method... cannot be used on mac
+            print("Python 2 fork() does not work on MacOS. Please use Python 3 instead.")
 
     audio_filename, audio_rate = extract_audio(source_path)
 

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -233,6 +233,11 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
     """
     Given an input audio/video file, generate subtitles in the specified language and format.
     """
+    if "Darwin" in os.uname():
+        #the default unix fork method does not work on Mac OS
+        #need to use forkserver
+        multiprocessing.set_start_method('forkserver')
+
     audio_filename, audio_rate = extract_audio(source_path)
 
     regions = find_speech_regions(audio_filename)

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -237,7 +237,8 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
         #the default unix fork method does not work on Mac OS
         #need to use forkserver
         try:
-            multiprocessing.set_start_method('forkserver')
+            if 'forkserver' not in multiprocessing.get_start_method():
+                multiprocessing.set_start_method('forkserver')
         except AttributeError:
             # for python 2 not have set_start_method... cannot be used on mac
             print("Python 2 fork() does not work on MacOS. Please use Python 3 instead.")


### PR DESCRIPTION
When running on MacOS High Sierra, soon after starting the multiprocessing.pool it was crashing completely with error below:

> The process has forked and you cannot use this CoreFoundation \
> functionality safely. You MUST exec().
> Break on __THE_PROCESS_HAS_FORKED_AND_YOU_CANNOT_USE_THIS_\
> COREFOUNDATION_FUNCTIONALITY___YOU_MUST_EXEC__() to debug.

According to documentation of multiprocessing: https://docs.python.org/3.4/library/multiprocessing.html

> fork
> The parent process uses os.fork() to fork the Python interpreter. The child process, when it begins, is effectively identical to the parent process. All resources of the parent are inherited by the child process. Note that safely forking a multithreaded process is problematic.
> Available on Unix only. The default on Unix.
> 
> forkserver
> When the program starts and selects the forkserver start method, a server process is started. From then on, whenever a new process is needed, the parent process connects to the server and requests that it fork a new process. The fork server process is single threaded so it is safe for it to use os.fork(). No unnecessary resources are inherited.

The default unix fork is not safe for threads... and MacOS doesn't seem to like that... crashing completely.

