### PR TITLE
Using https speech-to-text api instead of http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 MANIFEST
 *#*
 .vscode
+/.idea

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Autosub is a utility for automatic speech recognition and subtitle generation. I
 $ autosub -h
 usage: autosub [-h] [-C CONCURRENCY] [-o OUTPUT] [-F FORMAT] [-S SRC_LANGUAGE]
                [-D DST_LANGUAGE] [-K API_KEY] [--list-formats]
-               [--list-languages]
+               [--list-languages] [-htp]
                [source_path]
 
 positional arguments:
@@ -40,6 +40,8 @@ optional arguments:
                         subtitle translation)
   --list-formats        List all available subtitle formats
   --list-languages      List all available source/destination languages
+  -htp, --http-speech-to-text-api
+                        Change the speech-to-text api url into the http one
 ```
 
 ### License

--- a/autosub/constants.py
+++ b/autosub/constants.py
@@ -5,7 +5,7 @@ Defines constants used by autosub.
 from __future__ import unicode_literals
 
 GOOGLE_SPEECH_API_KEY = "AIzaSyBOti4mM-6x9WDnZIjIeyEU21OpBXqWBgw"
-GOOGLE_SPEECH_API_URL = "http://www.google.com/speech-api/v2/recognize?client=chromium&lang={lang}&key={key}" # pylint: disable=line-too-long
+GOOGLE_SPEECH_API_URL = "www.google.com/speech-api/v2/recognize?client=chromium&lang={lang}&key={key}" # pylint: disable=line-too-long
 
 LANGUAGE_CODES = {
     'af': 'Afrikaans',


### PR DESCRIPTION
According to this repo [google-speech-v2](https://github.com/gillesdemey/google-speech-v2) and my test, it is ok to change the api url into the https' one. There's no influence on the recognition result. And https is safer than http.
And I also add a fall back argument to choose http or https version url to use.

```
-htp, --http-speech-to-text-api    Change the speech-to-text api url into the http one
```
 