### PR TITLE
Added arguments for min and max region size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: python
 python:
   - "2.7"
-install:
-  - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: python
 python:
   - "2.7"
+install:
+  - pip install .
+  - pip install pylint
+script:
+  - pylint autosub

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ python:
   - "2.7"
 install:
   - pip install .
-  - pip install pylint
-script:
-  - pylint autosub

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Autosub <a href="https://pypi.python.org/pypi/autosub"><img src="https://img.shields.io/pypi/v/autosub.svg"></img></a>
 
-This is a modified verson of Autosub. I have added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").
+*This is a modified verson of Autosub. I have added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").*
 
-Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.
+*Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.*
 
 
 ### Auto-generated subtitles for any video

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Autosub <a href="https://pypi.python.org/pypi/autosub"><img src="https://img.shields.io/pypi/v/autosub.svg"></img></a>
-  
+
+This is a modified verson of Autosub. I have added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").
+
+Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.
+
+
 ### Auto-generated subtitles for any video
 
 Autosub is a utility for automatic speech recognition and subtitle generation. It takes a video or an audio file as input, performs voice activity detection to find speech regions, makes parallel requests to Google Web Speech API to generate transcriptions for those regions, (optionally) translates them to a different language, and finally saves the resulting subtitles to disk. It supports a variety of input and output languages (to see which, run the utility with the argument `--list-languages`) and can currently produce subtitles in either the [SRT format](https://en.wikipedia.org/wiki/SubRip) or simple [JSON](https://en.wikipedia.org/wiki/JSON).

--- a/README.md
+++ b/README.md
@@ -1,52 +1,9 @@
-# Autosub <a href="https://pypi.python.org/pypi/autosub"><img src="https://img.shields.io/pypi/v/autosub.svg"></img></a>
+# Autosub
 
-*This is a modified verson of Autosub. I have added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").*
+This is a modified verson of [Autosub](https://github.com/agermanidis/autosub). I have added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").
 
-*Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.*
+Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.
 
-
-### Auto-generated subtitles for any video
-
-Autosub is a utility for automatic speech recognition and subtitle generation. It takes a video or an audio file as input, performs voice activity detection to find speech regions, makes parallel requests to Google Web Speech API to generate transcriptions for those regions, (optionally) translates them to a different language, and finally saves the resulting subtitles to disk. It supports a variety of input and output languages (to see which, run the utility with the argument `--list-languages`) and can currently produce subtitles in either the [SRT format](https://en.wikipedia.org/wiki/SubRip) or simple [JSON](https://en.wikipedia.org/wiki/JSON).
-
-### Installation
-
-1. Install [ffmpeg](https://www.ffmpeg.org/).
-2. Run `pip install autosub`.
-
-### Usage
-
-```
-$ autosub -h
-usage: autosub [-h] [-C CONCURRENCY] [-o OUTPUT] [-F FORMAT] [-S SRC_LANGUAGE]
-               [-D DST_LANGUAGE] [-K API_KEY] [--list-formats]
-               [--list-languages]
-               [source_path]
-
-positional arguments:
-  source_path           Path to the video or audio file to subtitle
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -C CONCURRENCY, --concurrency CONCURRENCY
-                        Number of concurrent API requests to make
-  -o OUTPUT, --output OUTPUT
-                        Output path for subtitles (by default, subtitles are
-                        saved in the same directory and name as the source
-                        path)
-  -F FORMAT, --format FORMAT
-                        Destination subtitle format
-  -S SRC_LANGUAGE, --src-language SRC_LANGUAGE
-                        Language spoken in source file
-  -D DST_LANGUAGE, --dst-language DST_LANGUAGE
-                        Desired language for the subtitles
-  -K API_KEY, --api-key API_KEY
-                        The Google Translate API key to be used. (Required for
-                        subtitle translation)
-  --list-formats        List all available subtitle formats
-  --list-languages      List all available source/destination languages
-```
-
-### License
-
-MIT
+Added arguments:
+  -m MIN, --min MIN     Minimum region size
+  -M MAX, --max MAX     Maximum region size

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Autosub
 
-This is a modified verson of [Autosub](https://github.com/agermanidis/autosub). I have added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").
+This is a modified verson of [Autosub](https://github.com/agermanidis/autosub) with added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").
 
 Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.
 

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -238,6 +238,8 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
         dst_language=DEFAULT_DST_LANGUAGE,
         subtitle_file_format=DEFAULT_SUBTITLE_FORMAT,
         api_key=None,
+        min_region_size=0.5,
+        max_region_size=6,
     ):
     """
     Given an input audio/video file, generate subtitles in the specified language and format.
@@ -375,6 +377,10 @@ def main():
                         action='store_true')
     parser.add_argument('--list-languages', help="List all available source/destination languages",
                         action='store_true')
+    parser.add_argument('-m', '--min', help="Minimum region size",
+                        default=0.5)
+    parser.add_argument('-M', '--max', help="Maximum region size",
+                        default=6)
 
     args = parser.parse_args()
 
@@ -402,6 +408,8 @@ def main():
             api_key=args.api_key,
             subtitle_file_format=args.format,
             output=args.output,
+            min_region_size=int(args.min),
+            max_region_size=int(args.max),
         )
         print("Subtitles file created at {}".format(subtitle_file_path))
     except KeyboardInterrupt:

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -35,7 +35,6 @@ DEFAULT_CONCURRENCY = 10
 DEFAULT_SRC_LANGUAGE = 'en'
 DEFAULT_DST_LANGUAGE = 'en'
 
-
 def percentile(arr, percent):
     """
     Calculate the given percentile of arr.
@@ -237,16 +236,16 @@ def generate_subtitles( # pylint: disable=too-many-locals,too-many-arguments
         src_language=DEFAULT_SRC_LANGUAGE,
         dst_language=DEFAULT_DST_LANGUAGE,
         subtitle_file_format=DEFAULT_SUBTITLE_FORMAT,
-        api_key=None,
         min_region_size=0.5,
         max_region_size=6,
+        api_key=None,
     ):
     """
     Given an input audio/video file, generate subtitles in the specified language and format.
     """
     audio_filename, audio_rate = extract_audio(source_path)
 
-    regions = find_speech_regions(audio_filename)
+    regions = find_speech_regions(audio_filename, min_region_size=min_region_size, max_region_size=max_region_size)
 
     pool = multiprocessing.Pool(concurrency)
     converter = FLACConverter(source_path=audio_filename)
@@ -356,6 +355,8 @@ def main():
     """
     Run autosub as a command-line program.
     """
+
+
     parser = argparse.ArgumentParser()
     parser.add_argument('source_path', help="Path to the video or audio file to subtitle",
                         nargs='?')
@@ -370,6 +371,10 @@ def main():
                         default=DEFAULT_SRC_LANGUAGE)
     parser.add_argument('-D', '--dst-language', help="Desired language for the subtitles",
                         default=DEFAULT_DST_LANGUAGE)
+    parser.add_argument('-m', '--min', help="Minimum region size",
+                        default=0.5)
+    parser.add_argument('-M', '--max', help="Maximum region size",
+                        default=6)
     parser.add_argument('-K', '--api-key',
                         help="The Google Translate API key to be used. \
                         (Required for subtitle translation)")
@@ -377,10 +382,6 @@ def main():
                         action='store_true')
     parser.add_argument('--list-languages', help="List all available source/destination languages",
                         action='store_true')
-    parser.add_argument('-m', '--min', help="Minimum region size",
-                        default=0.5)
-    parser.add_argument('-M', '--max', help="Maximum region size",
-                        default=6)
 
     args = parser.parse_args()
 
@@ -407,9 +408,9 @@ def main():
             dst_language=args.dst_language,
             api_key=args.api_key,
             subtitle_file_format=args.format,
-            output=args.output,
             min_region_size=int(args.min),
             max_region_size=int(args.max),
+            output=args.output,
         )
         print("Subtitles file created at {}".format(subtitle_file_path))
     except KeyboardInterrupt:


### PR DESCRIPTION
Added arguments for minimum and maximum region size (length of audio to be transcribed in each "subtitle").

Personally I found this very convenient when using autosub to transcribe interviews (yes, autosub works great for that application), but it might be useful in other cases too.