### PR TITLE
Add external speech region control by using an external subtitle file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     install_requires=[
         'google-api-python-client>=1.4.2',
         'requests>=2.3.0',
+        'pysubs2>=0.2.4',
         'pysrt>=1.0.1',
         'progressbar2>=3.34.3',
         'six>=1.11.0',


### PR DESCRIPTION
Add external speech region control by using the times from an external subtitle file. File's format need to be supported by [pysubs2](https://pysubs2.readthedocs.io/en/latest/api-reference.html#supported-input-output-formats).