### PR TITLE
Converted to syntax usable with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.7"
 install:
   - pip install .
   - pip install pylint

--- a/autosub/__init__.py
+++ b/autosub/__init__.py
@@ -4,7 +4,7 @@ Defines autosub's main functionality.
 
 #!/usr/bin/env python
 
-from __future__ import absolute_import, print_function, unicode_literals
+
 
 import argparse
 import audioop
@@ -329,14 +329,14 @@ def validate(args):
         )
         return False
 
-    if args.src_language not in LANGUAGE_CODES.keys():
+    if args.src_language not in list(LANGUAGE_CODES.keys()):
         print(
             "Source language not supported. "
             "Run with --list-languages to see all supported languages."
         )
         return False
 
-    if args.dst_language not in LANGUAGE_CODES.keys():
+    if args.dst_language not in list(LANGUAGE_CODES.keys()):
         print(
             "Destination language not supported. "
             "Run with --list-languages to see all supported languages."

--- a/autosub/constants.py
+++ b/autosub/constants.py
@@ -2,7 +2,7 @@
 Defines constants used by autosub.
 """
 
-from __future__ import unicode_literals
+
 
 GOOGLE_SPEECH_API_KEY = "AIzaSyBOti4mM-6x9WDnZIjIeyEU21OpBXqWBgw"
 GOOGLE_SPEECH_API_URL = "http://www.google.com/speech-api/v2/recognize?client=chromium&lang={lang}&key={key}" # pylint: disable=line-too-long

--- a/autosub/formatters.py
+++ b/autosub/formatters.py
@@ -3,7 +3,7 @@ Defines subtitle formatters used by autosub.
 """
 
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 import json
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ long_description = (
 setup(
     name='autosub',
     version='0.5.0',
+    python_requires='>=3',
     description='Auto-generates subtitles for any video or audio file',
     long_description=long_description,
     author='Anastasis Germanidis',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import unicode_literals
+
 
 try:
     from setuptools import setup
@@ -20,7 +20,7 @@ long_description = (
 
 setup(
     name='autosub',
-    version='0.4.0',
+    version='0.5.0',
     description='Auto-generates subtitles for any video or audio file',
     long_description=long_description,
     author='Anastasis Germanidis',


### PR DESCRIPTION
Simply ran python's 2to3 tool on the contents of the repo and added `python_requires='>=3'` to setup.py.

Brief usage tests showed that it seemed to function fine with python 3 now